### PR TITLE
Using string expansion instead of awk to get true branch name

### DIFF
--- a/helmfile/scripts/apply.sh
+++ b/helmfile/scripts/apply.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 if [[ $BRANCH == *"/"* ]]; then
-  export BRANCH=$(echo $BRANCH | awk -F'/' '{print $3}')
+  export BRANCH=$(echo ${BRANCH#*/})
 fi
 echo "Deploying to: $BRANCH" 
 az account set -s $SUBSCRIPTION


### PR DESCRIPTION
Fixing issue when deploying "merge" branches. All merge branches will now be deployed to "merge" environment.